### PR TITLE
Add support for Cassandra chat message history

### DIFF
--- a/langchain/src/stores/message/cassandra.ts
+++ b/langchain/src/stores/message/cassandra.ts
@@ -1,0 +1,132 @@
+import {
+  BaseMessage,
+  BaseListChatMessageHistory,
+  StoredMessage,
+} from "../../schema/index.js";
+import {
+  mapChatMessagesToStoredMessages,
+  mapStoredMessagesToChatMessages,
+} from "./utils.js";
+import axiosMod, { AxiosRequestConfig } from "axios";
+
+export interface CassandraJsonApiConfig {
+  keyspace: string;
+  table: string;
+  astraId?: string;
+  astraRegion?: string;
+  astraKeyspace?: string;
+  astraApplicationToken?: string;
+}
+
+export interface Messages extends StoredMessage {
+  session_id: string;
+}
+export class CassandraChatMessageHistory extends BaseListChatMessageHistory {
+  lc_namespace = ["langchain", "stores", "message", "mongodb"];
+
+  private sessionId: string;
+
+  private readonly astraId: string | undefined;
+
+  private readonly astraRegion: string | undefined;
+
+  private readonly astraKeyspace: string | undefined;
+
+  private readonly astraApplicationToken: string | undefined;
+
+  private readonly table: string | undefined;
+
+  constructor(args: CassandraJsonApiConfig, sessionId: string) {
+    super();
+    this.sessionId = sessionId;
+    this.table = args.table;
+    this.astraId = args?.astraId;
+    this.astraRegion = args?.astraRegion;
+    this.astraKeyspace = args?.astraKeyspace;
+    this.astraApplicationToken = args?.astraApplicationToken;
+  }
+
+  async getMessages(): Promise<BaseMessage[]> {
+    let data = JSON.stringify({
+      find: {
+        filter: {
+          session_id: this.sessionId,
+        },
+      },
+    });
+    const config: AxiosRequestConfig = {
+      method: "post",
+      maxBodyLength: Infinity,
+      url: `https://${this.astraId}-${this.astraRegion}.apps.astra.datastax.com/api/json/v1/${this.astraKeyspace}/${this.table}`,
+      headers: {
+        "x-cassandra-token": this.astraApplicationToken ?? "",
+        "Content-Type": "application/json",
+      },
+      data: data,
+    };
+
+    const colection = await axiosMod.request(config);
+    const response = colection?.data?.data?.documents;
+
+    const messages: StoredMessage[] = response.map((res: any) => {
+      return {
+        type: res.type,
+        data: res.data,
+      };
+    });
+
+    return mapStoredMessagesToChatMessages(messages);
+  }
+
+  async addMessage(message: BaseMessage): Promise<void> {
+    const messageToAdd = mapChatMessagesToStoredMessages([message]);
+    let messages: Messages = {
+      session_id: this.sessionId,
+      ...messageToAdd[0],
+    };
+
+    const data = JSON.stringify({
+      insertOne: {
+        document: messages,
+      },
+    });
+
+    const config: AxiosRequestConfig = {
+      method: "post",
+      maxBodyLength: Infinity,
+      url: `https://${this.astraId}-${this.astraRegion}.apps.astra.datastax.com/api/json/v1/${this.astraKeyspace}/${this.table}`,
+      headers: {
+        "x-cassandra-token": this.astraApplicationToken ?? "",
+        "Content-Type": "application/json",
+      },
+      data: data,
+    };
+
+    await axiosMod.request(config);
+  }
+
+  async clear(): Promise<void> {
+    const data = JSON.stringify({
+      findOneAndDelete: {
+        filter: { session_id: this.sessionId },
+      },
+    });
+
+    const config: AxiosRequestConfig = {
+      method: "post",
+      maxBodyLength: Infinity,
+      url: `https://${this.astraId}-${this.astraRegion}.apps.astra.datastax.com/api/json/v1/${this.astraKeyspace}/${this.table}`,
+      headers: {
+        "x-cassandra-token": this.astraApplicationToken ?? "",
+        "Content-Type": "application/json",
+      },
+      data: data,
+    };
+
+    const resp = await axiosMod.request(config);
+
+    if (resp.data.status.deletedCount === 1) {
+      await this.clear();
+    }
+  }
+}

--- a/langchain/src/stores/tests/cassandra.int.test.ts
+++ b/langchain/src/stores/tests/cassandra.int.test.ts
@@ -1,0 +1,92 @@
+import { test, expect, describe } from "@jest/globals";
+import { AIMessage, HumanMessage } from "../../schema/index.js";
+import { CassandraChatMessageHistory } from "../message/cassandra.js";
+import { v4 } from "uuid";
+import { BufferMemory } from "../../memory/buffer_memory.js";
+import { ChatOpenAI } from "../../chat_models/openai.js";
+import { ConversationChain } from "../../chains/conversation.js";
+
+describe("Cassandra message history", () => {
+  const cassandraJsonApiConfig = {
+    keyspace: "test",
+    table: "messages",
+
+    astraId: process.env.ASTRA_DB_ID as string,
+    astraRegion: process.env.ASTRA_DB_REGION as string,
+    astraKeyspace: process.env.ASTRA_DB_KEYSPACE as string,
+    astraApplicationToken: process.env.ASTRA_DB_APPLICATION_TOKEN as string,
+  };
+
+  test("Test Cassandra history store and clear", async () => {
+    const id = v4();
+    const chatHistory = new CassandraChatMessageHistory(
+      cassandraJsonApiConfig,
+      id
+    );
+
+    const beforeMessages = await chatHistory.getMessages();
+    expect(beforeMessages).toStrictEqual([]);
+
+    await chatHistory.addUserMessage("Hi! I am alex.");
+    await chatHistory.addAIChatMessage(
+      "Hello, Alex! How can I assist you today?"
+    );
+
+    const expectedMessages = [
+      new HumanMessage("Hi! I am alex."),
+      new AIMessage("Hello, Alex! How can I assist you today?"),
+    ];
+
+    const resultWithHistory = await chatHistory.getMessages();
+
+    expect(resultWithHistory.sort()).toEqual(expectedMessages.sort());
+
+    await chatHistory.clear();
+
+    const blankResult = await chatHistory.getMessages();
+    expect(blankResult).toStrictEqual([]);
+  });
+
+  test("Test Cassandra memory with Buffer Memory", async () => {
+    const id = v4();
+    const memory = new BufferMemory({
+      returnMessages: true,
+      chatHistory: new CassandraChatMessageHistory(cassandraJsonApiConfig, id),
+    });
+
+    await memory.saveContext(
+      { input: "Hi! I am alex." },
+      { response: "Hello, Alex! How can I assist you today?" }
+    );
+
+    const expectedHistory = [
+      new HumanMessage("Hi! I am alex."),
+      new AIMessage("Hello, Alex! How can I assist you today?"),
+    ];
+    const result2 = await memory.loadMemoryVariables({});
+
+    expect(result2).toEqual({ history: expectedHistory });
+  });
+
+  test("Test Cassandra memory with LLM Chain", async () => {
+    const id = v4();
+    const memory = new BufferMemory({
+      returnMessages: true,
+      chatHistory: new CassandraChatMessageHistory(cassandraJsonApiConfig, id),
+    });
+
+    const model = new ChatOpenAI({
+      modelName: "gpt-3.5-turbo",
+      temperature: 0,
+    });
+    const chain = new ConversationChain({ llm: model, memory });
+
+    const res1 = await chain.call({ input: "Hi! I am alex." });
+    console.log({ res1 });
+
+    const res2 = await chain.call({
+      input: "What was my name?",
+    });
+    console.log({ res2 });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

- Add support for Cassandra chat message history.
- Test coverage for Cassandra message history.

Run integration tests with `yarn run test:single langchain/src/stores/tests/cassandra.int.test.ts`
